### PR TITLE
Use AbortController and PointerCapture correctly

### DIFF
--- a/src/lib/classes/styling/GlobalCssSchemesLoader.ts
+++ b/src/lib/classes/styling/GlobalCssSchemesLoader.ts
@@ -45,7 +45,7 @@ class GlobalCssSchemesLoader {
 
 	/**
 	 * Method for applying CSS variabels for a specific mediafeature
-	 * @param feature
+	 * @param {z.infer<typeof MediaScheme>} feature
 	 */
 	applyCssVariables(feature: z.infer<typeof MediaScheme>) {
 		// Apply color variables
@@ -136,8 +136,8 @@ class GlobalCssSchemesLoader {
 
 	/**
 	 * Method for checking and creating CSS color string
-	 * @param color
-	 * @returns CSS color string
+	 * @param {z.infer<typeof ColorValue>} color
+	 * @returns {string} CSS color string
 	 */
 	private createCssColor(color: z.infer<typeof ColorValue>): string {
 		let cssColor: string;

--- a/src/lib/components/console/Console.svelte
+++ b/src/lib/components/console/Console.svelte
@@ -24,7 +24,7 @@
 
 	/**
 	 * Function for resizing the console
-	 * @param event
+	 * @param {PointerEvent} event
 	 */
 	function resizeConsolePanel(event: PointerEvent) {
 		event.preventDefault();
@@ -38,7 +38,7 @@
 
 	/**
 	 * Function for starting resizing the console
-	 * @param event
+	 * @param {PointerEvent} event
 	 */
 	function startResizingConsolePanel(event: PointerEvent) {
 		event.preventDefault();
@@ -57,7 +57,7 @@
 
 	/**
 	 * Function for stopping resizing the console
-	 * @param event
+	 * @param {PointerEvent} event
 	 */
 	function stopResizingConsolePanel(event: PointerEvent) {
 		consoleContainer.releasePointerCapture(event.pointerId);
@@ -88,7 +88,7 @@
 
 	/**
 	 *Function for changing the current tab of the console
-	 *@param tab
+	 *@param {Tabs} tab
 	 */
 	function changeTab(tab: Tabs) {
 		currentTab = tab;
@@ -96,8 +96,8 @@
 
 	/**
 	 *Function for sending an error to a specific tab in the console
-	 *@param error
-	 *@param tab
+	 *@param {string} error
+	 *@param {Tabs} tab
 	 */
 	export function sendErrorToTab(error: string, tab: Tabs) {
 		switch (tab) {

--- a/src/lib/components/sidePanel/SidePanel.svelte
+++ b/src/lib/components/sidePanel/SidePanel.svelte
@@ -2,12 +2,15 @@
 	import { SidePanelEnum } from "./SidePanelEnum";
 
 	export let panelSide: SidePanelEnum;
-	export let mainContainer: HTMLElement;
+
+	let resizer: HTMLElement;
 	let panelWidth: number = 300;
+	let controller: AbortController;
+	let signal: AbortSignal;
 
 	/**
 	 * Function for resizing a sidepanel
-	 * @param event
+	 * @param {MouseEvent} event
 	 */
 	function resizeSidePanel(event: MouseEvent) {
 		event.preventDefault();
@@ -20,33 +23,40 @@
 
 	/**
 	 * Function for starting resizing a side panel
-	 * @param event
+	 * @param {PointerEvent} event
 	 */
 	function startResizingSidePanel(event: PointerEvent) {
+		controller = new AbortController();
+		signal = controller.signal;
+
 		event.preventDefault();
-		mainContainer.setPointerCapture(event.pointerId);
-		mainContainer.addEventListener("pointermove", resizeSidePanel);
-		mainContainer.addEventListener("pointerup", stopResizingSidePanel);
-		mainContainer.addEventListener("pointercancel", stopResizingSidePanel);
+		event.stopPropagation();
+
+		resizer.setPointerCapture(event.pointerId);
+		resizer.addEventListener("pointermove", resizeSidePanel, {
+			signal,
+		});
+		resizer.addEventListener("pointerup", stopResizingSidePanel, {
+			signal,
+		});
+		resizer.addEventListener("pointercancel", stopResizingSidePanel, {
+			signal,
+		});
 	}
 
 	/**
 	 * Function for stopping resizing a side panel
-	 * @param event
+	 * @param {PointerEvent} event
 	 */
 	function stopResizingSidePanel(event: PointerEvent) {
-		mainContainer.releasePointerCapture(event.pointerId);
-		mainContainer.removeEventListener("pointermove", resizeSidePanel);
-		mainContainer.removeEventListener("pointerup", stopResizingSidePanel);
-		mainContainer.removeEventListener(
-			"pointercancel",
-			stopResizingSidePanel,
-		);
+		resizer.releasePointerCapture(event.pointerId);
+		controller.abort();
 	}
 </script>
 
 {#if panelSide === SidePanelEnum.Right}
 	<div
+		bind:this={resizer}
 		role="button"
 		id="right-resizer"
 		class="resizer"
@@ -66,6 +76,7 @@
 </div>
 {#if panelSide === SidePanelEnum.Left}
 	<div
+		bind:this={resizer}
 		role="button"
 		id="left-resizer"
 		class="resizer"

--- a/src/lib/components/svg-view/DraggableSVG.svelte
+++ b/src/lib/components/svg-view/DraggableSVG.svelte
@@ -5,19 +5,31 @@
 
 	export let position: iPoint;
 
+	let element: SVGElement;
 	let controller: AbortController;
 	let signal: AbortSignal;
 
-	//Sets up eventlisteners when the mouse is pressed down on the svg
-	function onPointerDown() {
+	/**
+	 * Function for setting up event listeners when the mouse is pressed down on the svg
+	 * @param {PointerEvent} event
+	 */
+	function onPointerDown(event: PointerEvent) {
 		controller = new AbortController();
 		signal = controller.signal;
-		window.addEventListener("pointermove", onPointerMove, { signal });
-		window.addEventListener("pointerup", onPointerUp, { signal });
-		window.addEventListener("pointercancel", onPointerUp, { signal });
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		element.setPointerCapture(event.pointerId);
+		element.addEventListener("pointermove", onPointerMove, { signal });
+		element.addEventListener("pointerup", onPointerUp, { signal });
+		element.addEventListener("pointercancel", onPointerUp, { signal });
 	}
 
-	//Updates the position of the svg
+	/**
+	 * Function for updating the position of the svg
+	 * @param {PointerEvent} event
+	 */
 	function onPointerMove(event: PointerEvent) {
 		position.x += event.movementX / $scale;
 		position.y += event.movementY / $scale;
@@ -26,8 +38,12 @@
 		activeView.fastUpdate();
 	}
 
-	//Removes the eventlisteners when the mouse is released using abortcontroller
-	function onPointerUp() {
+	/**
+	 * Function for removing the event listeners when the mouse is released using AbortController
+	 * @param {PointerEvent} event
+	 */
+	function onPointerUp(event: PointerEvent) {
+		element.releasePointerCapture(event.pointerId);
 		controller.abort();
 
 		// Update the active view properly
@@ -36,6 +52,13 @@
 </script>
 
 <!-- The svg element that is draggable -->
-<g on:pointerdown={onPointerDown} role="none" class="draggable panzoom-exclude">
+<g
+	bind:this={element}
+	on:pointerdown={(event) => {
+		onPointerDown(event);
+	}}
+	role="none"
+	class="draggable panzoom-exclude"
+>
 	<slot />
 </g>

--- a/src/lib/components/svg-view/SvgView.svelte
+++ b/src/lib/components/svg-view/SvgView.svelte
@@ -40,6 +40,7 @@
 	/**
 	 * When the svg is zoomed, we update the svelte store with the new scale.
 	 * We need to know this value when we move stuff with the cursor, such as when moving locations.
+	 * @param {PanzoomChangeEvent} event
 	 */
 	function scaleChange(event: PanzoomChangeEvent) {
 		$scale = event.detail.scale;
@@ -47,6 +48,7 @@
 
 	/**
 	 * This function is called by the panzoom class, to set the correct svg zoom.
+	 * @param {CurrentValues} { x, y, scale }
 	 */
 	let transform: string | undefined;
 	function setTransform({ x, y, scale }: CurrentValues) {
@@ -55,6 +57,7 @@
 
 	/**
 	 * This function is called by the panzoom class, to enable or disable zoom animations.
+	 * @param {boolean} active
 	 */
 	let transition: string = "none";
 	function setTransition(active: boolean) {
@@ -63,6 +66,11 @@
 		transition = active ? `transform ${duration}ms ${easing}` : "none";
 	}
 
+	/**
+	 * Filters an array of edges to only include AutomatonEdges.
+	 * @param {SystemEdge[] | AutomatonEdge[] | undefined} edges - The array of edges to filter.
+	 * @returns {AutomatonEdge[]} - The filtered array of AutomatonEdges.
+	 */
 	function filterSystemEdges(
 		edges: SystemEdge[] | AutomatonEdge[] | undefined,
 	): AutomatonEdge[] {
@@ -72,6 +80,11 @@
 		);
 	}
 
+	/**
+	 * Returns an array of locations for a given active view.
+	 * @param {TActiveView} view - The active view to get the locations from.
+	 * @returns {Array} - An array of locations.
+	 */
 	function locationsAsArray(view: TActiveView) {
 		if (view instanceof Component) {
 			// TODO: support more than just components

--- a/src/lib/components/svg-view/SvgView.svelte
+++ b/src/lib/components/svg-view/SvgView.svelte
@@ -40,7 +40,6 @@
 	/**
 	 * When the svg is zoomed, we update the svelte store with the new scale.
 	 * We need to know this value when we move stuff with the cursor, such as when moving locations.
-	 * @param {PanzoomChangeEvent} event
 	 */
 	function scaleChange(event: PanzoomChangeEvent) {
 		$scale = event.detail.scale;
@@ -48,7 +47,6 @@
 
 	/**
 	 * This function is called by the panzoom class, to set the correct svg zoom.
-	 * @param {CurrentValues} { x, y, scale }
 	 */
 	let transform: string | undefined;
 	function setTransform({ x, y, scale }: CurrentValues) {
@@ -57,7 +55,6 @@
 
 	/**
 	 * This function is called by the panzoom class, to enable or disable zoom animations.
-	 * @param {boolean} active
 	 */
 	let transition: string = "none";
 	function setTransition(active: boolean) {
@@ -66,11 +63,6 @@
 		transition = active ? `transform ${duration}ms ${easing}` : "none";
 	}
 
-	/**
-	 * Filters an array of edges to only include AutomatonEdges.
-	 * @param {SystemEdge[] | AutomatonEdge[] | undefined} edges - The array of edges to filter.
-	 * @returns {AutomatonEdge[]} - The filtered array of AutomatonEdges.
-	 */
 	function filterSystemEdges(
 		edges: SystemEdge[] | AutomatonEdge[] | undefined,
 	): AutomatonEdge[] {
@@ -80,11 +72,6 @@
 		);
 	}
 
-	/**
-	 * Returns an array of locations for a given active view.
-	 * @param {TActiveView} view - The active view to get the locations from.
-	 * @returns {Array} - An array of locations.
-	 */
 	function locationsAsArray(view: TActiveView) {
 		if (view instanceof Component) {
 			// TODO: support more than just components

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,20 +11,18 @@
 	import Queries from "$lib/components/query/Queries.svelte";
 	import QueryNav from "$lib/components/query/QueryNav.svelte";
 	import ProjectItems from "$lib/components/project/ProjectItems.svelte";
-
-	let mainContainer: HTMLElement;
 </script>
 
 <!-- Top navigation Panel -->
 <nav id="main-nav">
 	<TopBar />
 </nav>
-<main bind:this={mainContainer}>
+<main>
 	{#if $project === undefined}
 		<StartScreen />
 	{:else}
 		<!-- Left side -->
-		<SidePanel panelSide={SidePanelEnum.Left} {mainContainer}>
+		<SidePanel panelSide={SidePanelEnum.Left}>
 			<ProjectNav slot="nav" />
 			<div slot="content">
 				<GlobalDeclaration />
@@ -37,7 +35,7 @@
 			<SvgView />
 		</div>
 		<!-- Right side -->
-		<SidePanel panelSide={SidePanelEnum.Right} {mainContainer}>
+		<SidePanel panelSide={SidePanelEnum.Right}>
 			<QueryNav slot="nav" />
 			<div slot="content">
 				<Queries />


### PR DESCRIPTION
Closes #104 

### Additions
Now using abortcontrollers in SidePanel and simplified SidePanel and DraggableSvg components by using pointer capture correctly.

By using pointerCapture we are now able to add eventlisteners to the component itself instead of some parent component.
