### PR TITLE
Clicking frontend/backend opens console

### DIFF
--- a/src/lib/components/console/Console.svelte
+++ b/src/lib/components/console/Console.svelte
@@ -91,6 +91,9 @@
 	 *@param tab
 	 */
 	function changeTab(tab: Tabs) {
+		if (currentlyCollapsed) {
+			changeConsoleCollapsableTextAndHeight();
+		}
 		currentTab = tab;
 	}
 


### PR DESCRIPTION
Closes #115

### Changes/Additions:
Clicking the _**Backend**_ or _**Frontend**_ console buttons when the console is collapsed now opens the console like in the old GUI.