### PR TITLE
edge scales by zoom level and arrow color is fixed

### DIFF
--- a/src/lib/components/svg-view/Edge.svelte
+++ b/src/lib/components/svg-view/Edge.svelte
@@ -3,6 +3,7 @@
 	import type { iPoint } from "$lib/interfaces/iPoint";
 	import type { iNail } from "$lib/interfaces/iNail";
 	import Nail from "./Nail.svelte";
+	import { scale } from "$lib/globalState/scaleStore";
 
 	export let sourcePoint: iPoint;
 	export let targetPoint: iPoint;
@@ -47,7 +48,7 @@
 	function calculateX2(line: { from: iPoint; to: iPoint }): number {
 		return (
 			line.to.x -
-			20 *
+			25 *
 				Math.cos(
 					Math.atan2(
 						line.to.y - line.from.y,
@@ -61,7 +62,7 @@
 	function calculateY2(line: { from: iPoint; to: iPoint }): number {
 		return (
 			line.to.y -
-			20 *
+			25 *
 				Math.sin(
 					Math.atan2(
 						line.to.y - line.from.y,
@@ -70,6 +71,9 @@
 				)
 		);
 	}
+
+	$: dashedStroke =
+		edgeType === Status.INPUT ? `${2 * 8 - $scale},${2 * 8 - $scale}` : "";
 </script>
 
 <!-- Lines -->
@@ -80,7 +84,7 @@
 		x2={index === lines.length - 1 ? calculateX2(line) : line.to.x}
 		y2={index === lines.length - 1 ? calculateY2(line) : line.to.y}
 		marker-end={index === lines.length - 1 ? "url(#arrowhead)" : ""}
-		stroke-dasharray={edgeType === Status.INPUT ? "10,10" : ""}
+		stroke-dasharray={dashedStroke}
 		id="edge-{edgeType}-{index}"
 	/>
 {/each}

--- a/src/lib/components/svg-view/SvgView.svelte
+++ b/src/lib/components/svg-view/SvgView.svelte
@@ -121,15 +121,16 @@
 		<!-- Arrowhead used at the end of edges -->
 		<defs>
 			<marker
+				class="arrowhead"
 				id="arrowhead"
-				viewBox="0 0 10 10"
+				viewBox="0 0 15 15"
 				refX="10"
 				refY="5"
 				markerWidth="6"
 				markerHeight="6"
 				orient="auto-start-reverse"
 			>
-				<path d="M 0 0 L 10 5 L 0 10 z" fill="black" />
+				<path d="M 5 0 L 15 5 L 5 10 z" />
 			</marker>
 		</defs>
 	</g>
@@ -151,5 +152,9 @@
 	.panzoom-element {
 		user-select: none;
 		touch-action: none;
+	}
+
+	.arrowhead {
+		fill: var(--canvas-action-color);
 	}
 </style>


### PR DESCRIPTION
Closes #128 

### Changes/Additions:

- [edge scales by zoom level and arrow color is fixed](https://github.com/ECDAR-AAU-SW-P5/Ecdar-GUI-Web/commit/18c54d347cd9a9c845a85636916d5d9955b120e7)

scaling:
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbTl3azl5ZXR5bG5xbHM0Nnk2Ym0zZTV6ZXdsbG5ycTBhNWN6OGV4MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EhpzRLLp7elGvNTkWu/giphy.gif)
color (this also works for light theme)
![](https://cdn.discordapp.com/attachments/1016280813526056983/1177224632223416330/image.png?ex=6571bae0&is=655f45e0&hm=d76b995d4f987706b36a995c49ac26e1ad9a7b8013a754f2d1217f8852721098&)

