### PR TITLE
Add panzoom disclaimers to all panzoom files

### DIFF
--- a/src/lib/components/svg-view/panzoom/css.ts
+++ b/src/lib/components/svg-view/panzoom/css.ts
@@ -1,3 +1,12 @@
+/**
+ * @file
+ * Code adapted from https://www.npmjs.com/package/@panzoom/panzoom/v/4.5.1
+ * The original code is not very optimized for svelte. CSS values are set at runtime instead of compile time, and events are handled outside of the svelte event loop.
+ * We have forked the code to integrate it correctly with svelte.
+ *
+ * PLEASE DO NOT MODIFY unless it is very necessary. This code is intentionally structured to follow the source code, to make future upgrades/debugging easier.
+ */
+
 import type { CurrentValues } from "./types";
 
 /**

--- a/src/lib/components/svg-view/panzoom/isExcluded.ts
+++ b/src/lib/components/svg-view/panzoom/isExcluded.ts
@@ -1,3 +1,12 @@
+/**
+ * @file
+ * Code adapted from https://www.npmjs.com/package/@panzoom/panzoom/v/4.5.1
+ * The original code is not very optimized for svelte. CSS values are set at runtime instead of compile time, and events are handled outside of the svelte event loop.
+ * We have forked the code to integrate it correctly with svelte.
+ *
+ * PLEASE DO NOT MODIFY unless it is very necessary. This code is intentionally structured to follow the source code, to make future upgrades/debugging easier.
+ */
+
 import type { PanzoomOptions } from "./types";
 
 function getClass(elem: Element) {

--- a/src/lib/components/svg-view/panzoom/pointers.ts
+++ b/src/lib/components/svg-view/panzoom/pointers.ts
@@ -1,4 +1,13 @@
 /**
+ * @file
+ * Code adapted from https://www.npmjs.com/package/@panzoom/panzoom/v/4.5.1
+ * The original code is not very optimized for svelte. CSS values are set at runtime instead of compile time, and events are handled outside of the svelte event loop.
+ * We have forked the code to integrate it correctly with svelte.
+ *
+ * PLEASE DO NOT MODIFY unless it is very necessary. This code is intentionally structured to follow the source code, to make future upgrades/debugging easier.
+ */
+
+/**
  * Utilites for working with multiple pointer events
  */
 

--- a/src/lib/components/svg-view/panzoom/types.ts
+++ b/src/lib/components/svg-view/panzoom/types.ts
@@ -1,3 +1,12 @@
+/**
+ * @file
+ * Code adapted from https://www.npmjs.com/package/@panzoom/panzoom/v/4.5.1
+ * The original code is not very optimized for svelte. CSS values are set at runtime instead of compile time, and events are handled outside of the svelte event loop.
+ * We have forked the code to integrate it correctly with svelte.
+ *
+ * PLEASE DO NOT MODIFY unless it is very necessary. This code is intentionally structured to follow the source code, to make future upgrades/debugging easier.
+ */
+
 export type PanzoomEvent =
 	| "panzoomstart"
 	| "panzoomchange"


### PR DESCRIPTION
Since all this code will be used in our exams, we should make it expressly clear when we are using code that we did not write ourselves. Therefore we should add disclaimer comments to all files imported from the [panzoom package](https://www.npmjs.com/package/@panzoom/panzoom/v/4.5.1), which we did not write.