### PR TITLE
Fix clearing behavior in activeView

### DIFF
--- a/src/lib/globalState/activeProject.ts
+++ b/src/lib/globalState/activeProject.ts
@@ -250,6 +250,6 @@ function closeActiveViewIfDeleted() {
 			activeViewValue,
 		)
 	) {
-		activeViewValue = undefined;
+		activeView.set(undefined);
 	}
 }


### PR DESCRIPTION
The activeView store was set up to clear itself if the parent project was cleared, but it only cleared the value, it did not notify subscribers of the change. This fixes the issue and ensures that subscribers are notified when the store is cleared.

Fixes #161