### PR TITLE
Remove broken delete implementation

### DIFF
--- a/src/lib/components/contextMenu/contentTypes/locationMenu/LocationMenu.svelte
+++ b/src/lib/components/contextMenu/contentTypes/locationMenu/LocationMenu.svelte
@@ -23,11 +23,23 @@
 		icon={Delete}
 		text="Delete"
 		click={() => {
-			location.remove();
+			// TODO: implement
 		}}
 	/>
-	<Button icon={Warning} text="Deattach" click={() => {}} />
-	<Button icon={Star} text="Star" click={() => {}} />
+	<Button
+		icon={Warning}
+		text="Deattach"
+		click={() => {
+			// TODO: implement
+		}}
+	/>
+	<Button
+		icon={Star}
+		text="Star"
+		click={() => {
+			// TODO: implement
+		}}
+	/>
 </Panel>
 <Panel>
 	<p>Color</p>


### PR DESCRIPTION
The delete feature was part of an early proof-of-concept, that was always meant to be reworked. Unfortunately, editing capabilities are out of scope for our work, so the correct thing is to remove it and let the next group work with it.
